### PR TITLE
updated webpack-cli@^3.1.2 to fix build script error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "style-loader": "^0.20.3",
     "webpack": "^4.1.1",
     "webpack-bundle-analyzer": "^2.11.1",
-    "webpack-cli": "^2.0.11",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.1"
   }
 }


### PR DESCRIPTION
Not much of a PR but I noticed webpack-cli@2.0.11 is outdated when following along your FrontendMaster workshop build script portion. 

v2 package
![image](https://user-images.githubusercontent.com/4703475/49530934-351a7580-f887-11e8-90c1-b26fa626e334.png)

v3 package update
![image](https://user-images.githubusercontent.com/4703475/49531182-b83bcb80-f887-11e8-89b3-337bc4a9cfae.png)
